### PR TITLE
fix a potential warning of size_t

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -45,7 +45,7 @@ static void Usage() {
 
 
 static std::string GetExtension(const std::string& filename) {
-  return filename.substr(std::max(0UL, filename.size() - 2));
+  return filename.substr(std::max(static_cast<std::size_t>(0), filename.size() - 2));
 }
 
 


### PR DESCRIPTION
The actual type of size_t is platform-dependent; we cannot simply assume it as a unsigned long.

@wgtdkp please review it.