### PR TITLE
Simplify useless dynamic allocation

### DIFF
--- a/src/cpp.cc
+++ b/src/cpp.cc
@@ -812,11 +812,9 @@ void Preprocessor::AddMacro(const std::string& name,
 static std::string* Date() {
   time_t t = time(NULL);
   struct tm* tm = localtime(&t);
-  auto buf = new char[14];
-  strftime(buf, 14, "\"%a %M %Y\"", tm);
-  auto ret = new std::string(buf);
-  delete[] buf;
-  return ret;
+  char buf[14];
+  strftime(buf, sizeof buf, "\"%a %M %Y\"", tm);
+  return new std::string(buf);
 }
 
 

--- a/src/cpp.cc
+++ b/src/cpp.cc
@@ -437,7 +437,7 @@ void Preprocessor::ParseLine(TokenSequence ls) {
   size_t end = 0;
   try {
     line = stoi(tok->str_, &end, 10);
-  } catch (const std::out_of_range oor) {
+  } catch (const std::out_of_range& oor) {
     Error(tok, "line number out of range");
   }
   if (line == 0 || end != tok->str_.size()) {


### PR DESCRIPTION
No need for using 'new/delete' here.