### PR TITLE
Use standard function 'remove'

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -248,7 +248,6 @@ int main(int argc, char* argv[]) {
     }
   }
   auto ret = RunGcc();
-  auto cmd = "rm -f " + filename_out;
-  if (system(cmd.c_str())) {}
+  remove(filename_out.c_str());
   return ret;
 }


### PR DESCRIPTION
This is more portable and safer than relying on the shell (e.g the filename could contains spaces).