### PR TITLE
Mark 'Error' functions as 'noreturn'

### DIFF
--- a/src/cpp.cc
+++ b/src/cpp.cc
@@ -729,7 +729,6 @@ bool Preprocessor::ParseIdentList(ParamList& params, TokenSequence& is) {
   }
 
   Error(tok, "unexpected end of line");
-  return false; // Make compiler happy
 }
 
 

--- a/src/error.cc
+++ b/src/error.cc
@@ -37,6 +37,7 @@ void Error(const char* format, ...) {
 }
 
 
+[[noreturn]]
 static void VError(const SourceLocation& loc,
                    const char* format,
                    va_list args) {

--- a/src/error.h
+++ b/src/error.h
@@ -7,9 +7,9 @@ class Token;
 class Expr;
 
 
-void Error(const char* format, ...);
-void Error(const SourceLocation& loc, const char* format, ...);
-void Error(const Token* tok, const char* format, ...);
-void Error(const Expr* expr, const char* format, ...);
+[[noreturn]] void Error(const char* format, ...);
+[[noreturn]] void Error(const SourceLocation& loc, const char* format, ...);
+[[noreturn]] void Error(const Token* tok, const char* format, ...);
+[[noreturn]] void Error(const Expr* expr, const char* format, ...);
 
 #endif


### PR DESCRIPTION
Remove corresponding ("make the compiler happy") workarounds from caller code.