### PR TITLE
Reduce memory leaks

### DIFF
--- a/src/cpp.h
+++ b/src/cpp.h
@@ -76,7 +76,7 @@ public:
   const Token* ParseActualParam(TokenSequence& is, Macro* macro, ParamMap& paramMap);
   int GetDirective(TokenSequence& is);
   const Token* EvalDefOp(TokenSequence& is);
-  void ReplaceIdent(TokenSequence& is);
+  void ReplaceIdent(TokenSequence& is, TokenSequence& os);
   void ParseDirective(TokenSequence& os, TokenSequence& is, int directive);
   void ParseIf(TokenSequence ls);
   void ParseIfdef(TokenSequence ls);

--- a/src/main.cc
+++ b/src/main.cc
@@ -92,7 +92,8 @@ static int RunWgtcc() {
   if (specified_out_name) {
     fp = fopen(filename_out.c_str(), "w");
   }
-  TokenSequence ts;
+  TokenList tokenList;
+  TokenSequence ts(&tokenList);
   cpp.Process(ts);
   if (only_preprocess) {
     ts.Print(fp);


### PR DESCRIPTION
Hello @wgtdkp 
This is a pull request to fix some of the memory leaks found in wtgcc, as reported by Valgrind.
The fixes are quite simple and they follow your style.
Even if the program frees all the memory after the program exits. I recommend this fix because it makes the code better and it can offer less troubles to someone else, who wants to use this project differently. 
Thanks!